### PR TITLE
投稿作成APIにおいてなんちゃってクリーンアーキテクチャを適用

### DIFF
--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\Post\StoreRequest;
+use App\Http\Resources\PostResource;
 use App\Models\Community;
 use App\Models\Post;
 use App\Models\User;
@@ -42,10 +43,6 @@ class PostController extends Controller
         $post->community()->associate($community);
         $post->save();
 
-        return response()->json([
-            'id' => $post->id,
-            'title' => $post->title,
-            'body' => $post->body
-        ]);
+        return response()->json(new PostResource($post));
     }
 }

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -23,12 +23,7 @@ class PostController extends Controller
         $user = $request->user();
 
         // 認可
-        $userBelongsToCommuity = $community->users()
-            ->wherePivot('user_id', $user->id)
-            ->exists();
-        if (!$userBelongsToCommuity) {
-            throw new AccessDeniedException('ユーザは指定されたコミュニティに所属していません');
-        }
+        $this->authorize('store', [Post::class, $community]);
 
         // フォーマットバリデーション
         $validator = Validator::make($request->all(), [

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -6,11 +6,8 @@ use App\Http\Requests\Post\StoreRequest;
 use App\Http\Resources\PostResource;
 use App\Models\Community;
 use App\Models\Post;
-use App\Models\User;
-use Carbon\Carbon;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Validator;
-use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
+use App\UseCases\Post\PostLimitExceededException;
+use App\UseCases\Post\StoreAction;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 class PostController extends Controller
@@ -20,7 +17,7 @@ class PostController extends Controller
      *
      * というエンドポイントで， {community} に指定された ID でルートモデルバインディング
      */
-    public function store(StoreRequest $request, Community $community)
+    public function store(StoreRequest $request, Community $community, StoreAction $action)
     {
         // 認可
         $user = $request->user();
@@ -29,20 +26,11 @@ class PostController extends Controller
         // フォーマットバリデーション
         $post = $request->makePost();
 
-        // ドメインバリデーション
-        $userPostsCountToday = $user->posts()
-            ->where('community_id', $community->id)
-            ->where('created_at', '>=', Carbon::createMidnightDate())
-            ->count();
-
-        if ($userPostsCountToday >= 2) {
-            throw new TooManyRequestsHttpException(null, '本日の投稿可能な回数を超えました。');
+        try {
+            // ドメインバリデーションを呼び出す
+            return response()->json(new PostResource($action($user, $community, $post)));
+        } catch (PostLimitExceededException $e) {
+            throw new TooManyRequestsHttpException(null, $e->getMessage(), $e);
         }
-
-        $post->user()->associate($user);
-        $post->community()->associate($community);
-        $post->save();
-
-        return response()->json(new PostResource($post));
     }
 }

--- a/src/app/Http/Requests/Post/StoreRequest.php
+++ b/src/app/Http/Requests/Post/StoreRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Post;
+
+use App\Models\Post;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:30',
+            'body' => 'required|string|max:10000',
+        ];
+    }
+
+    public function makePost(): Post
+    {
+        // バリデーションした値で埋めた Post を取得
+        return new Post($this->validated());
+    }
+}

--- a/src/app/Http/Resources/PostResource.php
+++ b/src/app/Http/Resources/PostResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'title' => $this->resource->title,
+            'body' => $this->resource->body,
+        ];
+    }
+}

--- a/src/app/Policies/PostPolicy.php
+++ b/src/app/Policies/PostPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Community;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+// memo: Policyの仕様でUserモデルは認証済みユーザーを自動で取得して渡される
+class PostPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * ログインユーザーがポストの登録が可能か
+     */
+    public function store(User $user, Community $community)
+    {
+        $userBelongsToCommuity = $community->users()
+            ->wherePivot('user_id', $user->id)
+            ->exists();
+
+        return $userBelongsToCommuity;
+    }
+}

--- a/src/app/Providers/AuthServiceProvider.php
+++ b/src/app/Providers/AuthServiceProvider.php
@@ -13,7 +13,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+        'App\Post' => 'App\Policies\PostPolicy',
     ];
 
     /**

--- a/src/app/UseCases/Post/PostLimitExceededException.php
+++ b/src/app/UseCases/Post/PostLimitExceededException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\UseCases\Post;
+
+use Exception;
+
+class PostLimitExceededException extends Exception
+{
+    public function __construct(
+      string $message = "",
+      protected int $error_code = 1
+    )
+    {
+        parent::__construct($message, $error_code);
+    }
+}

--- a/src/app/UseCases/Post/StoreAction.php
+++ b/src/app/UseCases/Post/StoreAction.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\UseCases\Post;
+
+use App\Models\Community;
+use App\Models\Post;
+use App\Models\User;
+use Carbon\Carbon;
+
+class StoreAction
+{
+    public function __invoke(User $user, Community $community, Post $post): Post
+    {
+        $userPostsCountToday = $user->posts()
+          ->where('community_id', $community->id)
+          ->where('created_at', '>=', Carbon::createMidnightDate())
+          ->count();
+
+        if ($userPostsCountToday >= 2) {
+          throw new PostLimitExceededException('本日の投稿可能な回数を超えました。');
+        }
+
+        $post->user()->associate($user);
+        $post->community()->associate($community);
+        $post->save();
+
+        return $post;
+    }
+}

--- a/src/database/seeders/UserSeeder.php
+++ b/src/database/seeders/UserSeeder.php
@@ -19,5 +19,11 @@ class UserSeeder extends Seeder
             'email' => 'test@akinori.com',
             'password' => Hash::make('akinoringo123')
         ]);
+
+        User::factory()->create([
+            'name' => 'テストユーザー',
+            'email' => 'test2@akinori.com',
+            'password' => Hash::make('akinoringo123')
+        ]);
     }
 }


### PR DESCRIPTION
## 対応内容
- 認可処理をPolicyに切り出し
- フォーマットバリデーションをフォームリクエストに切り出し
- レスポンスの整形処理をResouceクラスに切り出し
- UseCaseディレクトリをとりいれたなんちゃってクリーンアーキテクチャの導入

## テスト
- 投稿作成APIのテスト